### PR TITLE
Kotlin api improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ This is a small lib to use easily use Android's ViewModels with a depedency inje
 [![Sonatype Snapshot](https://img.shields.io/nexus/s/https/oss.sonatype.org/me.tatarka.injectedvmprovider/injectedvmprovider.svg)](https://oss.sonatype.org/content/repositories/snapshots/me/tatarka/injectedvmprovider/)
 
 ```groovy
-implementation 'me.tatarka.injectedvmprovider:injectedvmprovider-extensions:2.1.1'
+implementation 'me.tatarka.injectedvmprovider:injectedvmprovider:2.2.0-SNAPSHOT'
 ```
 
 #### Usage
 
 Set up your ViewModel
+
 ```java
 public class MyViewModel extends ViewModel {
     private final MyDependency source;
@@ -28,6 +29,7 @@ public class MyViewModel extends ViewModel {
 ```
 
 Inject your ViewModel provider into the desired Fragment or Activity
+
 ```java
 public class MyActivity extends AppCompatActivity {
 
@@ -38,36 +40,71 @@ public class MyActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ...
-        MyViewModel vm = InjectedViewModelProviders.of(this).get(vmProvider);
+        MyViewModel vm = InjectedViewModelProvider.of(this).get(vmProvider);
     }
 }
 ```
-Note: If you aren't using fragments, you can use `me.tatarka.injectedvmprovider:injectedvmprovider:2.1.1`, and use `new InjectedViewModelProvider(viewModelStoreOwner)` instead.
-
-
 
 If you have a factory, you can inject that instead. This is useful for passing in intent arguments to the view model, and/or with [assisted injection](https://github.com/square/AssistedInject).
+For the key, you can either pass the factory instance or the view model class.
 
 ```java
-@Inject
-MyViewModel.Factory vmFactory;
-
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ...
-    MyViewModel vm = InjectedViewModelProviders.of(this).get(vmFactory, factory -> factory.create("arg"));
-}
+class MyActivity extends ComponentActivity {
+    @Inject
+    MyViewModel.Factory vmFactory;
+    
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        MyViewModel vm = InjectedViewModelProvider.of(this).get(vmFactory, factory -> factory.create("arg"));
+        MyViewModel vm2 = InjectedViewModelProvider.of(this).get(MyViweModel.class, () -> vmFactory.create("arg"));
+    }
+} 
 ```
 
 ### From Kotlin
 
 #### Download
+
 ```groovy
-implementation 'me.tatarka.injectedvmprovider:injectedvmprovider-ktx:2.1.1'
+implementation 'me.tatarka.injectedvmprovider:injectedvmprovider-ktx:2.2.0-SNAPSHOT'
 ```
 
 #### Usage
+
+Set up your ViewModel
+
+```kotlin
+class MyViewModel @Inject constructor(val source: MyDependency) {
+}
+```
+
+Use the `viewModel` delegate to obtain a view model from an injected provider.
+
+```kotlin
+class MyFragment @Inject constructor(val vmProvider: Provider<MyViweModel>) {
+    val vm by viewModel(vmProvider)
+}
+```
+
+If you have field injection or are using a factory, you pass a lambda to view model instead.  
+
+```kotlin
+class MyActivity: ComponentActivity {
+    @Inject
+    latinit var vmProvider: Provider<MyViewModel>
+    @Inject
+    latinit var vmFactory: MyViewModel.Factory
+    
+    val vm by viewModel { vmProvider.get() }
+    val vm2 by viewModel { vmFactory.create("arg") }
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        inject(this)
+    }
+}
+```
 
 ViewModel
 ```kotlin

--- a/injectedvmprovider-extensions/src/main/java/me/tatarka/injectedvmprovider/InjectedViewModelProviders.java
+++ b/injectedvmprovider-extensions/src/main/java/me/tatarka/injectedvmprovider/InjectedViewModelProviders.java
@@ -4,11 +4,12 @@ import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
-
+import androidx.lifecycle.ViewModelStoreOwner;
 
 /**
  * Utilities methods for {@link androidx.lifecycle.ViewModelStore} class.
  */
+@Deprecated
 public class InjectedViewModelProviders {
 
     /**
@@ -17,8 +18,10 @@ public class InjectedViewModelProviders {
      *
      * @param fragment a fragment, in whose scope ViewModels should be retained
      * @return a ViewModelProvider instance
+     * @deprecated Use {@link InjectedViewModelProvider#of(ViewModelStoreOwner)} instead.
      */
     @MainThread
+    @Deprecated
     public static InjectedViewModelProvider of(@NonNull Fragment fragment) {
         return new InjectedViewModelProvider(fragment.getViewModelStore());
     }
@@ -29,9 +32,11 @@ public class InjectedViewModelProviders {
      *
      * @param activity an activity, in whose scope ViewModels should be retained
      * @return a ViewModelProvider instance
+     * @deprecated Use {@link InjectedViewModelProvider#of(ViewModelStoreOwner)} instead.
      */
     @NonNull
     @MainThread
+    @Deprecated
     public static InjectedViewModelProvider of(@NonNull FragmentActivity activity) {
         return new InjectedViewModelProvider(activity.getViewModelStore());
     }

--- a/injectedvmprovider-ktx/build.gradle
+++ b/injectedvmprovider-ktx/build.gradle
@@ -24,6 +24,9 @@ android {
 dependencies {
     implementation project(':injectedvmprovider')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
 
 repositories {

--- a/injectedvmprovider-ktx/src/main/java/InjectedViewModelLazy.kt
+++ b/injectedvmprovider-ktx/src/main/java/InjectedViewModelLazy.kt
@@ -1,0 +1,48 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package me.tatarka.injectedvmprovider
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import javax.inject.Provider
+
+/**
+ * Returns a [Lazy] delegate to access the ViewModelStoreOwner's ViewModel. The given provider will
+ * be used to construct the ViewModel the first time it's accessed.
+ *
+ * ```
+ * class MyFragment @Inject constructor(private val provider) : Fragment() {
+ *     val myViewModel by viewModel(provider)
+ * }
+ * ```
+ */
+@MainThread
+inline fun <VM : ViewModel> ViewModelStoreOwner.viewModel(provider: Provider<VM>): Lazy<VM> {
+    return lazy(mode = LazyThreadSafetyMode.NONE) {
+        InjectedViewModelProvider.of(this).get(provider)
+    }
+}
+
+/**
+ * Returns a [Lazy] delegate to access the ViewModelStoreOwner's ViewModel. The given factory will
+ * be used to construct the ViewModel the first time it's accessed. This is useful if the
+ * construction of the ViewModel takes parameters, or if the provider needs to be lazily provider
+ * because this declaration happens before injection.
+ *
+ * ```
+ * class MyComponentActivity : ComponentActivity() {
+ *     lateinit var provider: Provider<MyViewModel1>
+ *     lateinit var factory: MyViewModel2.Factory
+ *
+ *     val myViewModel1 by viewModel { provider.get() }
+ *     val myViewModel2 by viewModel { factory.create("arg") }
+ * }
+ * ```
+ */
+@MainThread
+inline fun <reified VM : ViewModel> ViewModelStoreOwner.viewModel(noinline factory: () -> VM): Lazy<VM> {
+    return lazy(mode = LazyThreadSafetyMode.NONE) {
+        InjectedViewModelProvider.of(this).get(VM::class.java, factory)
+    }
+}

--- a/injectedvmprovider-ktx/src/main/java/ktx/ViewStoreOwnerExt.kt
+++ b/injectedvmprovider-ktx/src/main/java/ktx/ViewStoreOwnerExt.kt
@@ -3,5 +3,7 @@ package me.tatarka.injectedvmprovider.ktx
 import androidx.lifecycle.ViewModelStoreOwner
 import me.tatarka.injectedvmprovider.InjectedViewModelProvider
 
+@Deprecated(message = "Use InjectedViewModelProvider.of() or by viewModel() instead", replaceWith = ReplaceWith("InjectedViewModelProvider.of(this)"))
 inline val ViewModelStoreOwner.injectedViewModelProvider: InjectedViewModelProvider
     get() = InjectedViewModelProvider(this)
+

--- a/injectedvmprovider-ktx/src/test/java/InjectedViewModelLazyTest.kt
+++ b/injectedvmprovider-ktx/src/test/java/InjectedViewModelLazyTest.kt
@@ -1,0 +1,48 @@
+package me.tatarka.injectedvmprovider
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import javax.inject.Provider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InjectedViewModelLazyTest {
+
+    @Test
+    fun vmInitialization() {
+        val owner = TestViewModelStoreOwner()
+        owner.onCreate()
+        assertEquals("arg1", owner.vm.arg)
+        assertEquals("arg1", owner.lazyVM.arg)
+        assertEquals("arg2", owner.factoryVM.arg)
+        assertEquals("arg2", owner.lazyFactoryVM.arg)
+    }
+
+    class TestViewModelStoreOwner : ViewModelStoreOwner {
+        lateinit var lazyVMProvider: TestViewModelProvider
+        lateinit var lazyVMFactory: TestViewModelFactory
+
+        val vm by viewModel(TestViewModelProvider())
+        val factoryVM by viewModel { TestViewModelFactory().create("arg2") }
+        val lazyVM by viewModel { lazyVMProvider.get() }
+        val lazyFactoryVM by viewModel { lazyVMFactory.create("arg2") }
+
+        override fun getViewModelStore(): ViewModelStore = ViewModelStore()
+
+        fun onCreate() {
+            lazyVMProvider = TestViewModelProvider()
+            lazyVMFactory = TestViewModelFactory()
+        }
+    }
+
+    class TestViewModel(val arg: String) : ViewModel()
+
+    class TestViewModelProvider : Provider<TestViewModel> {
+        override fun get() = TestViewModel("arg1")
+    }
+
+    class TestViewModelFactory {
+        fun create(arg: String) = TestViewModel(arg)
+    }
+}

--- a/injectedvmprovider/build.gradle
+++ b/injectedvmprovider/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
@@ -24,6 +25,14 @@ android {
 dependencies {
     api "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
     api 'javax.inject:javax.inject:1'
+
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+}
+
+repositories {
+    mavenCentral()
 }
 
 apply from: '../publish.gradle'

--- a/injectedvmprovider/src/main/java/me/tatarka/injectedvmprovider/FactoryCreator.java
+++ b/injectedvmprovider/src/main/java/me/tatarka/injectedvmprovider/FactoryCreator.java
@@ -1,5 +1,11 @@
 package me.tatarka.injectedvmprovider;
 
+/**
+ * Creates an instance of a factory, allowing it to pass additional params.
+ *
+ * @param <F> The factory type.
+ * @param <T> The instance to create.
+ */
 public interface FactoryCreator<F, T> {
     T create(F factory);
 }

--- a/injectedvmprovider/src/main/java/me/tatarka/injectedvmprovider/InjectedViewModelProvider.java
+++ b/injectedvmprovider/src/main/java/me/tatarka/injectedvmprovider/InjectedViewModelProvider.java
@@ -1,11 +1,11 @@
 package me.tatarka.injectedvmprovider;
 
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelStore;
 import androidx.lifecycle.ViewModelStoreBridge;
 import androidx.lifecycle.ViewModelStoreOwner;
-import androidx.annotation.MainThread;
-import androidx.annotation.NonNull;
 
 import javax.inject.Provider;
 
@@ -25,7 +25,7 @@ import javax.inject.Provider;
  * @Override
  * public void onCreate(@Nullable Bundle savedInstanceState) {
  *     ...
- *     MyViewModel vm = InjectedViewModelProviders.of(this).get(vmProvider);
+ *     MyViewModel vm = InjectedViewModelProvider.of(this).get(vmProvider);
  * }
  * }</pre>
  */
@@ -33,6 +33,21 @@ public class InjectedViewModelProvider {
 
     private static final String DEFAULT_KEY =
             "android.arch.lifecycle.ViewModelProvider.DefaultKey";
+
+    /**
+     * Creates an {@link InjectedViewModelProvider}, which retains ViewModels while a scope of given
+     * {@code owner} is alive. More detailed explanation is in {@link androidx.lifecycle.ViewModel}.
+     *
+     * @param owner a {@code ViewModelStoreOwner} whose {@link ViewModelStore} will be used to
+     *              retain {@code ViewModels}
+     * @return an InjectedViewModelProvider instance
+     */
+    @NonNull
+    @MainThread
+    public static InjectedViewModelProvider of(@NonNull ViewModelStoreOwner owner) {
+        return new InjectedViewModelProvider(owner.getViewModelStore());
+    }
+
     @NonNull
     private final ViewModelStore store;
 
@@ -43,6 +58,7 @@ public class InjectedViewModelProvider {
      * @param owner a {@code ViewModelStoreOwner} whose {@link ViewModelStore} will be used to
      *              retain {@code ViewModels}
      */
+    @MainThread
     public InjectedViewModelProvider(@NonNull ViewModelStoreOwner owner) {
         this(owner.getViewModelStore());
     }
@@ -53,6 +69,7 @@ public class InjectedViewModelProvider {
      *
      * @param store {@code ViewModelStore} where ViewModels will be stored.
      */
+    @MainThread
     public InjectedViewModelProvider(@NonNull ViewModelStore store) {
         this.store = store;
     }
@@ -69,11 +86,39 @@ public class InjectedViewModelProvider {
      *                 present.
      * @param <T>      The type parameter for the ViewModel.
      * @return A ViewModel that is an instance of the given type {@code T}.
+     * @throws IllegalArgumentException If the given provider is a local or anonymous class. If this
+     *                                  is the case, you must use {@link #get(String, Provider)} or {@link #get(Class, Provider)}
+     *                                  instead so a unique key can be derived.
      */
     @NonNull
     @MainThread
     public <T extends ViewModel> T get(@NonNull Provider<T> provider) {
         String canonicalName = provider.getClass().getCanonicalName();
+        if (canonicalName == null) {
+            throw new IllegalArgumentException("Local and anonymous classes can not be ViewModels");
+        }
+        return get(DEFAULT_KEY + ":" + canonicalName, provider);
+    }
+
+    /**
+     * Returns an existing ViewModel or creates a new one in the scope (usually, a fragment or
+     * an activity), associated with this {@code ViewModelProvider}.
+     * <p>
+     * The created ViewModel is associated with the given scope and will be retained
+     * as long as the scope is alive (e.g. if it is an activity, until it is
+     * finished or process is killed).
+     *
+     * @param viewModelClass The view model class, used as a unique key.
+     * @param provider       The provider of the ViewModel to create an instance of it if it is not
+     *                       present.
+     * @param <T>            The type parameter for the ViewModel.
+     * @return A ViewModel that is an instance of the given type {@code T}.
+     * @throws IllegalArgumentException If the given viewModelClass is a local or anonymous class.
+     */
+    @NonNull
+    @MainThread
+    public <T extends ViewModel> T get(@NonNull Class<T> viewModelClass, Provider<T> provider) {
+        String canonicalName = viewModelClass.getCanonicalName();
         if (canonicalName == null) {
             throw new IllegalArgumentException("Local and anonymous classes can not be ViewModels");
         }
@@ -123,7 +168,7 @@ public class InjectedViewModelProvider {
      */
     @NonNull
     @MainThread
-    public <F, T extends ViewModel> T get(@NonNull F factory, FactoryCreator<F, T> creator) {
+    public <F, T extends ViewModel> T get(@NonNull F factory, @NonNull FactoryCreator<F, T> creator) {
         String canonicalName = factory.getClass().getCanonicalName();
         if (canonicalName == null) {
             throw new IllegalArgumentException("Local and anonymous classes can not be ViewModels");
@@ -139,7 +184,7 @@ public class InjectedViewModelProvider {
      * as long as the scope is alive (e.g. if it is an activity, until it is
      * finished or process is killed).
      *
-     * @param key      The key to use to identify the ViewModel.
+     * @param key     The key to use to identify the ViewModel.
      * @param factory The factory of the ViewModel.
      * @param creator The factory creator of the ViewModel to create an instance of it if it is not
      *                present.
@@ -149,7 +194,7 @@ public class InjectedViewModelProvider {
      */
     @NonNull
     @MainThread
-    public <F, T extends ViewModel> T get(@NonNull String key, @NonNull F factory, FactoryCreator<F, T> creator) {
+    public <F, T extends ViewModel> T get(@NonNull String key, @NonNull F factory, @NonNull FactoryCreator<F, T> creator) {
         ViewModel viewModel = ViewModelStoreBridge.get(store, key);
         if (viewModel == null) {
             viewModel = creator.create(factory);
@@ -158,4 +203,5 @@ public class InjectedViewModelProvider {
         //noinspection unchecked
         return (T) viewModel;
     }
+
 }

--- a/injectedvmprovider/src/test/java/InjectedViewModelProviderTest.kt
+++ b/injectedvmprovider/src/test/java/InjectedViewModelProviderTest.kt
@@ -1,0 +1,99 @@
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import me.tatarka.injectedvmprovider.InjectedViewModelProvider
+import javax.inject.Provider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertSame
+
+class InjectedViewModelProviderTest {
+
+    private val viewModelProvider = InjectedViewModelProvider(ViewModelStore())
+
+    @Test
+    fun `two ViewModels with the same key causes a ClassCastException`() {
+        val key = "the key"
+        viewModelProvider[key, ViewModel1Provider]
+
+        val error = assertFails {
+            val vm2 = viewModelProvider[key, ViewModel2Provider]
+        }
+        assertEquals(ClassCastException::class, error::class)
+    }
+
+    @Test
+    fun `local ViewModel throws IllegalArgumentException`() {
+        class VM : ViewModel1()
+
+        val provider = Provider { VM() }
+
+        val error = assertFails {
+            viewModelProvider.get(provider)
+        }
+        assertEquals(IllegalArgumentException::class, error::class)
+    }
+
+    @Test
+    fun `two ViewModels with different types can both be constructed`() {
+        val model1 = viewModelProvider[ViewModel1Provider]
+        val model2 = viewModelProvider[ViewModel2Provider]
+        assertSame(model1, viewModelProvider[ViewModel1Provider])
+        assertSame(model2, viewModelProvider[ViewModel2Provider])
+    }
+
+    @Test
+    fun `ViewModels work when passing in a ViewModelStore owner`() {
+        val store = ViewModelStore()
+        val owner = ViewModelStoreOwner { store }
+        val provider = InjectedViewModelProvider(owner)
+        val vm = provider[ViewModel1Provider]
+
+        assertSame(provider[ViewModel1Provider], vm)
+    }
+
+    @Test
+    fun `ViewModel is constructed with provider arg`() {
+        val vm = viewModelProvider[ViewModel1Provider]
+
+        assertEquals("arg1", vm.arg)
+    }
+
+    @Test
+    fun `ViewModel is constructed with first lambda arg`() {
+        viewModelProvider[ViewModel1::class.java, Provider { ViewModel1("arg2") }]
+        val vm = viewModelProvider[ViewModel1::class.java, Provider { ViewModel1("ignored") }]
+
+        assertEquals("arg2", vm.arg)
+    }
+
+    @Test
+    fun `ViewModel is constructed with first FactoryCreator arg`() {
+        viewModelProvider[ViewModel1Factory, { it.create("arg2") }]
+        val vm = viewModelProvider[ViewModel1Factory, { it.create("ignored") }]
+
+        assertEquals("arg2", vm.arg)
+
+    }
+
+    open class ViewModel1(val arg: String = "", var cleared: Boolean = false) : ViewModel() {
+        override fun onCleared() {
+            cleared = true
+        }
+    }
+
+    object ViewModel1Provider : Provider<ViewModel1> {
+        override fun get() = ViewModel1("arg1")
+    }
+
+    object ViewModel1Factory {
+        fun create(arg: String) = ViewModel1(arg)
+    }
+
+    class ViewModel2 : ViewModel()
+
+    object ViewModel2Provider : Provider<ViewModel2> {
+        override fun get() = ViewModel2()
+    }
+}


### PR DESCRIPTION
- Deprecated ViewModelProviders and the -extensions package, you can use
ViewModelProvider instead.
- Add get overload that takes a viewModel class to allow using a lambda
as your provider.
- Add viewModel lazy delecate functions for nice init in kotlin